### PR TITLE
Made go snake compatible with new api

### DIFF
--- a/api.go
+++ b/api.go
@@ -5,115 +5,46 @@ import (
 	"net/http"
 )
 
-type StartRequest struct {
-	GameID int `json:"game_id"`
+type Coord struct {
+	X int `json:"x"`
+	Y int `json:"y"`
 }
 
-func NewStartRequest(req *http.Request) (*StartRequest, error) {
-	decoded := StartRequest{}
-	err := json.NewDecoder(req.Body).Decode(&decoded)
-	return &decoded, err
+type Snake struct {
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
+	Health int     `json:"health"`
+	Body   []Coord `json:"body"`
+}
+
+type Board struct {
+	Height int     `json:"height"`
+	Width  int     `json:"width"`
+	Food   []Coord `json:"food"`
+	Snakes []Snake `json:"snakes"`
+}
+
+type Game struct {
+	ID string `json:"id"`
+}
+
+type SnakeRequest struct {
+	Game  Game  `json:"game"`
+	Turn  int   `json:"turn"`
+	Board Board `json:"board"`
+	You   Snake `json:"you"`
 }
 
 type StartResponse struct {
-	Color          string   `json:"color,omitempty"`
-	Name           string   `json:"name,omitempty"`
-	HeadURL        string   `json:"head_url,omitempty"`
-	Taunt          string   `json:"taunt,omitempty"`
-	HeadType       HeadType `json:"head_type,omitempty"`
-	TailType       TailType `json:"tail_type,omitempty"`
-	SecondaryColor string   `json:"secondary_color,omitempty"`
-}
-
-type MoveRequest struct {
-	Food   PointList `json:"food"`
-	Height int       `json:"height"`
-	ID     int       `json:"id"`
-	Snakes SnakeList `json:"snakes"`
-	Turn   int       `json:"turn"`
-	Width  int       `json:"width"`
-	You    Snake     `json:"you"`
-}
-
-func NewMoveRequest(req *http.Request) (*MoveRequest, error) {
-	decoded := MoveRequest{}
-	err := json.NewDecoder(req.Body).Decode(&decoded)
-	return &decoded, err
+	Color string `json:"color,omitempty"`
 }
 
 type MoveResponse struct {
 	Move string `json:"move"`
 }
 
-type Snake struct {
-	Body   PointList `json:"body"`
-	Health int       `json:"health"`
-	ID     string    `json:"id"`
-	Length int       `json:"length"`
-	Name   string    `json:"name"`
-	Taunt  string    `json:"taunt"`
-}
-
-func (snake Snake) Head() Point { return snake.Body[0] }
-
-type Point struct {
-	X int `json:"x"`
-	Y int `json:"y"`
-}
-
-type HeadType string
-
-const (
-	HEAD_BENDR     HeadType = "bendr"
-	HEAD_DEAD               = "dead"
-	HEAD_FANG               = "fang"
-	HEAD_PIXEL              = "pixel"
-	HEAD_REGULAR            = "regular"
-	HEAD_SAFE               = "safe"
-	HEAD_SAND_WORM          = "sand-worm"
-	HEAD_SHADES             = "shades"
-	HEAD_SMILE              = "smile"
-	HEAD_TONGUE             = "tongue"
-)
-
-type TailType string
-
-const (
-	TAIL_BLOCK_BUM    TailType = "block-bum"
-	TAIL_CURLED                = "curled"
-	TAIL_FAT_RATTLE            = "fat-rattle"
-	TAIL_FRECKLED              = "freckled"
-	TAIL_PIXEL                 = "pixel"
-	TAIL_REGULAR               = "regular"
-	TAIL_ROUND_BUM             = "round-bum"
-	TAIL_SKINNY                = "skinny"
-	TAIL_SMALL_RATTLE          = "small-rattle"
-)
-
-// Parses List<Point> into []Point
-type PointList []Point
-
-func (list *PointList) UnmarshalJSON(data []byte) error {
-	var obj struct {
-		Data []Point `json:"data"`
-	}
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return err
-	}
-	*list = obj.Data
-	return nil
-}
-
-// Parses List<Snake> into []Snake
-type SnakeList []Snake
-
-func (list *SnakeList) UnmarshalJSON(data []byte) error {
-	var obj struct {
-		Data []Snake `json:"data"`
-	}
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return err
-	}
-	*list = obj.Data
-	return nil
+func DecodeSnakeRequest(req *http.Request) (*SnakeRequest, error) {
+	decoded := SnakeRequest{}
+	err := json.NewDecoder(req.Body).Decode(&decoded)
+	return &decoded, err
 }

--- a/api.go
+++ b/api.go
@@ -43,7 +43,7 @@ type MoveResponse struct {
 	Move string `json:"move"`
 }
 
-func DecodeSnakeRequest(req *http.Request) (*SnakeRequest, error) {
+func NewSnakeRequest(req *http.Request) (*SnakeRequest, error) {
 	decoded := SnakeRequest{}
 	err := json.NewDecoder(req.Body).Decode(&decoded)
 	return &decoded, err

--- a/api_test.go
+++ b/api_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"bytes"
 	"net/http"
-	"reflect"
 	"testing"
+	"github.com/stretchr/testify/assert"
 )
 
 var mockReq = `{
@@ -75,16 +75,13 @@ func createMockSnakeRequest() *SnakeRequest {
 	return &sr
 }
 
-func TestDecodeSnakeRequest(t *testing.T) {
+func TestNewSnakeRequest(t *testing.T) {
+	expected := &SnakeRequest{}
 	req := requestWithBody(mockReq)
-	result, err := DecodeSnakeRequest(req)
-
-	if err != nil {
-		t.Fatal(err)
+	
+	result, err := NewSnakeRequest(req)
+	if assert.NoError(t, err) {
+		expected = createMockSnakeRequest()
 	}
-	expected := createMockSnakeRequest()
-
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected:\n%#v\nGot:\n%#v", expected, result)
-	}
+	assert.Equal(t, result, expected)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -2,11 +2,43 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"reflect"
 	"testing"
 )
+
+var mockReq = `{
+	"game": {
+		"id": "abc"
+	},
+	"turn": 10,
+	"board": {
+		"height": 10,
+		"width": 10,
+		"food": [{
+				"x": 1,
+				"y": 1
+		}],
+		"snakes": [{
+			"id": "123",
+			"name": "snek",
+			"health": 1,
+			"body": [{
+					"x": 1,
+					"y": 1
+			}]
+		}]
+	},
+	"you": {
+		"id": "123",
+		"name": "snek",
+		"health": 1,
+		"body": [{
+				"x": 1,
+				"y": 1
+		}]
+	}
+}`
 
 func requestWithBody(body string) *http.Request {
 	req, err := http.NewRequest("", "", bytes.NewBufferString(body))
@@ -16,233 +48,43 @@ func requestWithBody(body string) *http.Request {
 	return req
 }
 
-func TestStartRequest(t *testing.T) {
-	s := `
-	{
-	  "game_id": 1234
+func createMockSnakeRequest() *SnakeRequest {
+	c := Coord{
+		X: 1,
+		Y: 1,
 	}
-	`
-	req := requestWithBody(s)
-	result, err := NewStartRequest(req)
-
-	if err != nil {
-		t.Fatal(err)
+	s := Snake{
+		ID:     "123",
+		Name:   "snek",
+		Health: 1,
+		Body:   []Coord{c},
 	}
-	expected := StartRequest{
-		GameID: 1234,
+	b := Board{
+		Height: 10,
+		Width:  10,
+		Food:   []Coord{c},
+		Snakes: []Snake{s},
 	}
-	if *result != expected {
-		t.Errorf("Expected:\n%#v\nGot:\n%#v", expected, result)
-	}
-}
-
-func TestNewStartResponse(t *testing.T) {
-	res := StartResponse{}
-
-	result, err := json.Marshal(res)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := "{}"
-	if string(result) != expected {
-		t.Errorf("Expected:\n%#v\nGot:\n%#v", expected, string(result))
-	}
-
-	res = StartResponse{
-		Color:          "#FF0000",
-		SecondaryColor: "#00FF00",
-		HeadURL:        "http://placecage.com/c/100/100",
-		Name:           "Cage Snake",
-		Taunt:          "OH GOD NOT THE BEES",
-		HeadType:       HEAD_SAND_WORM,
-		TailType:       TAIL_FAT_RATTLE,
-	}
-
-	result, err = json.MarshalIndent(res, "", "    ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected = `{
-    "color": "#FF0000",
-    "name": "Cage Snake",
-    "head_url": "http://placecage.com/c/100/100",
-    "taunt": "OH GOD NOT THE BEES",
-    "head_type": "sand-worm",
-    "tail_type": "fat-rattle",
-    "secondary_color": "#00FF00"
-}`
-
-	if string(result) != expected {
-		t.Errorf("Expected:\n%#v\nGot:\n%#v", expected, string(result))
-	}
-}
-
-func TestNewMoveRequest(t *testing.T) {
-	s := `
-	{
-	  "food": {
-		"data": [
-		  {
-			"object": "point",
-			"x": 0,
-			"y": 9
-		  }
-		],
-		"object": "list"
-	  },
-	  "height": 20,
-	  "id": 5,
-	  "object": "world",
-	  "snakes": {
-		"data": [
-		  {
-			"body": {
-			  "data": [
-				{
-				  "object": "point",
-				  "x": 13,
-				  "y": 19
-				},
-				{
-				  "object": "point",
-				  "x": 13,
-				  "y": 19
-				},
-				{
-				  "object": "point",
-				  "x": 13,
-				  "y": 19
-				}
-			  ],
-			  "object": "list"
-			},
-			"health": 100,
-			"id": "58a0142f-4cd7-4d35-9b17-815ec8ff8e70",
-			"length": 3,
-			"name": "Sonic Snake",
-			"object": "snake",
-			"taunt": "Gotta go fast"
-		  },
-		  {
-			"body": {
-			  "data": [
-				{
-				  "object": "point",
-				  "x": 8,
-				  "y": 15
-				},
-				{
-				  "object": "point",
-				  "x": 8,
-				  "y": 15
-				},
-				{
-				  "object": "point",
-				  "x": 8,
-				  "y": 15
-				}
-			  ],
-			  "object": "list"
-			},
-			"health": 100,
-			"id": "48ca23a2-dde8-4d0f-b03a-61cc9780427e",
-			"length": 3,
-			"name": "Typescript Snake",
-			"object": "snake",
-			"taunt": ""
-		  }
-		],
-		"object": "list"
-	  },
-	  "turn": 10,
-	  "width": 20,
-	  "you": {
-		"body": {
-		  "data": [
-			{
-			  "object": "point",
-			  "x": 8,
-			  "y": 15
-			},
-			{
-			  "object": "point",
-			  "x": 8,
-			  "y": 15
-			},
-			{
-			  "object": "point",
-			  "x": 8,
-			  "y": 15
-			}
-		  ],
-		  "object": "list"
-		},
-		"health": 100,
-		"id": "48ca23a2-dde8-4d0f-b03a-61cc9780427e",
-		"length": 3,
-		"name": "Typescript Snake",
-		"object": "snake",
-		"taunt": ""
-	  }
-	}
-	`
-
-	req := requestWithBody(s)
-	result, err := NewMoveRequest(req)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := MoveRequest{
-		Food:   PointList{Point{X: 0, Y: 9}},
-		Height: 20,
-		ID:     5,
-		Snakes: SnakeList{
-			Snake{
-				Body:   PointList{Point{X: 13, Y: 19}, Point{X: 13, Y: 19}, Point{X: 13, Y: 19}},
-				Health: 100,
-				ID:     "58a0142f-4cd7-4d35-9b17-815ec8ff8e70",
-				Length: 3,
-				Name:   "Sonic Snake",
-				Taunt:  "Gotta go fast",
-			},
-			Snake{
-				Body:   PointList{Point{X: 8, Y: 15}, Point{X: 8, Y: 15}, Point{X: 8, Y: 15}},
-				Health: 100,
-				ID:     "48ca23a2-dde8-4d0f-b03a-61cc9780427e",
-				Length: 3,
-				Name:   "Typescript Snake",
-				Taunt:  "",
-			},
-		},
+	g := Game{ID: "abc"}
+	sr := SnakeRequest{
+		Game:  g,
+		Board: b,
 		Turn:  10,
-		Width: 20,
-		You: Snake{
-			Body:   PointList{Point{X: 8, Y: 15}, Point{X: 8, Y: 15}, Point{X: 8, Y: 15}},
-			Health: 100,
-			ID:     "48ca23a2-dde8-4d0f-b03a-61cc9780427e",
-			Length: 3,
-			Name:   "Typescript Snake",
-			Taunt:  "",
-		},
+		You:   s,
 	}
-
-	if !reflect.DeepEqual(*result, expected) {
-		t.Errorf("Expected:\n%#v\nGot:\n%#v", expected, result)
-	}
+	return &sr
 }
 
-func TestMoveResponse(t *testing.T) {
-	res := MoveResponse{
-		Move: "up",
-	}
+func TestDecodeSnakeRequest(t *testing.T) {
+	req := requestWithBody(mockReq)
+	result, err := DecodeSnakeRequest(req)
 
-	result, err := json.Marshal(res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `{"move":"up"}`
-	if string(result) != expected {
-		t.Errorf("Expected:\n%#v\nGot:\n%#v", expected, string(result))
+	expected := createMockSnakeRequest()
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected:\n%#v\nGot:\n%#v", expected, result)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ func main() {
 
 	http.HandleFunc("/start", Start)
 	http.HandleFunc("/move", Move)
+	http.HandleFunc("/end", End)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/routes.go
+++ b/routes.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Start(res http.ResponseWriter, req *http.Request) {
-	data, err := DecodeSnakeRequest(req)
+	data, err := NewSnakeRequest(req)
 	if err != nil {
 		log.Printf("Bad start request: %v", err)
 	}
@@ -18,7 +18,7 @@ func Start(res http.ResponseWriter, req *http.Request) {
 }
 
 func Move(res http.ResponseWriter, req *http.Request) {
-	data, err := DecodeSnakeRequest(req)
+	data, err := NewSnakeRequest(req)
 	if err != nil {
 		log.Printf("Bad move request: %v", err)
 	}

--- a/routes.go
+++ b/routes.go
@@ -2,50 +2,33 @@ package main
 
 import (
 	"log"
-	"math/rand"
 	"net/http"
-	"time"
 )
 
 func Start(res http.ResponseWriter, req *http.Request) {
-	log.Print("START REQUEST")
-
-	data, err := NewStartRequest(req)
+	data, err := DecodeSnakeRequest(req)
 	if err != nil {
 		log.Printf("Bad start request: %v", err)
 	}
 	dump(data)
 
 	respond(res, StartResponse{
-		Taunt:          "battlesnake-go!",
-		Color:          "#75CEDD",
-		Name:           "battlesnake-go",
-		HeadType:       HEAD_PIXEL,
-		TailType:       TAIL_ROUND_BUM,
-		SecondaryColor: "#F7D3A2",
+		Color: "#75CEDD",
 	})
 }
 
 func Move(res http.ResponseWriter, req *http.Request) {
-	log.Printf("MOVE REQUEST")
-
-	data, err := NewMoveRequest(req)
-
+	data, err := DecodeSnakeRequest(req)
 	if err != nil {
 		log.Printf("Bad move request: %v", err)
 	}
 	dump(data)
 
-	directions := []string{
-		"up",
-		"down",
-		"left",
-		"right",
-	}
-
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	respond(res, MoveResponse{
-		Move: directions[r.Intn(4)],
+		Move: "down",
 	})
+}
+
+func End(res http.ResponseWriter, req *http.Request) {
+	return
 }


### PR DESCRIPTION
This PR does the following:
- makes the snake compatible with the new api as specified [here](https://github.com/battlesnakeio/docs/blob/master/apis/snake/spec.yaml)
- removes dead code
- simplifies the move handler so that the snake always default to down

Related issues: https://github.com/battlesnakeio/roadmap/issues/38